### PR TITLE
Fix that will provide the version parameter to foursquare

### DIFF
--- a/lib/passport-foursquare/strategy.js
+++ b/lib/passport-foursquare/strategy.js
@@ -17,9 +17,10 @@ var util = require('util')
  * credentials are not valid.  If an exception occured, `err` should be set.
  *
  * Options:
- *   - `clientID`      your Facebook application's App ID
- *   - `clientSecret`  your Facebook application's App Secret
- *   - `callbackURL`   URL to which Facebook will redirect the user after granting authorization
+ *   - `clientID`      your Foursquare application's App ID
+ *   - `clientSecret`  your Foursquare application's App Secret
+ *   - `callbackURL`   URL to which Foursquare will redirect the user after granting authorization
+ *   - `apiVersion`    the Foursquare API version to use for requesting the user profile
  *
  * Examples:
  *
@@ -43,9 +44,19 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://foursquare.com/oauth2/authorize';
   options.tokenURL = options.tokenURL || 'https://foursquare.com/oauth2/access_token';
+  options.apiVersion = options.apiVersion || '20120504';
   
   OAuth2Strategy.call(this, options, verify);
   this.name = 'foursquare';
+
+  // Foursquare expects a date-based version string to be passed in now and 
+  // has begun warning clients that do not include it with the following in
+  // the response:
+  // 
+  // errorType: 'deprecated',
+  // errorDetail: 'Please provide an API version to avoid future errors.See http://bit.ly/vywCav'
+  // 
+  this.apiVersion = options.apiVersion;
   
   // NOTE: Due to OAuth 2.0 implementations arising at different points and
   //       drafts in the specification process, the parameter used to denote the
@@ -79,7 +90,11 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get('https://api.foursquare.com/v2/users/self', accessToken, function (err, body, res) {
+  var selfPath = 'https://api.foursquare.com/v2/users/self';
+  if (this.apiVersion) {
+    selfPath += '?v=' + this.apiVersion;
+  }
+  this._oauth2.get(selfPath, accessToken, function (err, body, res) {
     if (err) { return done(err); }
     
     try {


### PR DESCRIPTION
This corrects the versioning issue: foursquare is asking developers to start including a verified version date string in their requests.

As implemented today, the passport-foursquare strategy returns profile JSON containing deprecation statements for not including the `?v=...` component in the self profile request.

Fixes this issue I opened as well:
https://github.com/jaredhanson/passport-foursquare/issues/1

Thanks!
