### PR TITLE
Avoid user to accept the the auth request every time.

### DIFF
--- a/lib/passport-foursquare/strategy.js
+++ b/lib/passport-foursquare/strategy.js
@@ -43,22 +43,22 @@ var util = require('util')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.authorizationURL = options.authorizationURL || 'https://foursquare.com/oauth2/authorize';
+  options.authorizationURL = options.authorizationURL || 'https://foursquare.com/oauth2/authenticate';
   options.tokenURL = options.tokenURL || 'https://foursquare.com/oauth2/access_token';
   options.apiVersion = options.apiVersion || '20120504';
-  
+
   OAuth2Strategy.call(this, options, verify);
   this.name = 'foursquare';
 
-  // Foursquare expects a date-based version string to be passed in now and 
+  // Foursquare expects a date-based version string to be passed in now and
   // has begun warning clients that do not include it with the following in
   // the response:
-  // 
+  //
   // errorType: 'deprecated',
   // errorDetail: 'Please provide an API version to avoid future errors.See http://bit.ly/vywCav'
-  // 
+  //
   this.apiVersion = options.apiVersion;
-  
+
   // NOTE: Due to OAuth 2.0 implementations arising at different points and
   //       drafts in the specification process, the parameter used to denote the
   //       access token is not always consistent.    As of OAuth 2.0 draft 22,
@@ -97,20 +97,20 @@ Strategy.prototype.userProfile = function(accessToken, done) {
   }
   this._oauth2.get(url, accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
       var json = JSON.parse(body);
-      
+
       var profile = { provider: 'foursquare' };
       profile.id = json.response.user.id;
       profile.name = { familyName: json.response.user.lastName,
                        givenName: json.response.user.firstName };
       profile.gender = json.response.user.gender;
       profile.emails = [{ value: json.response.user.contact.email }];
-      
+
       profile._raw = body;
       profile._json = json;
-      
+
       done(null, profile);
     } catch(e) {
       done(e);


### PR DESCRIPTION
Changed "/authorize" to "/authenticate". The user doesn't have to accept the the auth request every time (see "Authentication" paragraph https://developer.foursquare.com/overview/auth).
