### PR TITLE
Fix an example to prevent a warning about express

### DIFF
--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -48,7 +48,7 @@ passport.use(new FoursquareStrategy({
 
 
 
-var app = express.createServer();
+var app = express();
 
 // configure Express
 app.configure(function() {


### PR DESCRIPTION
I found the following warning when I started an example of this library.
I prevented this warning by this pull request.

```
$ node app
Warning: express.createServer() is deprecated, express
applications no longer inherit from http.Server,
             please use:

              var express = require("express");
              var app = express();
```
