### PR TITLE
adding display popup option

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -77,6 +77,28 @@ util.inherits(Strategy, OAuth2Strategy);
 
 
 /**
+ * Return extra Foursquare-specific parameters to be included in the authorization
+ * request.
+ *
+ * Options:
+ *  - `display`  Display mode to render dialog, { 'touch', 'wap', `webpopup` }.
+ *
+ * @param {Object} options
+ * @return {Object}
+ * @api protected
+ */
+Strategy.prototype.authorizationParams = function (options) {
+    var params = {};
+
+    // https://developer.foursquare.com/overview/auth#display
+    if (options.display) {
+        params.display = options.display;
+    }
+
+    return params;
+};
+
+/**
  * Retrieve user profile from Foursquare.
  *
  * This function constructs a normalized profile, with the following properties:


### PR DESCRIPTION
Accept if you'd like, a basic copy/paste from the facebook authorizationParams for foursquare to have an optional display type.

---

Display Types (https://developer.foursquare.com/overview/auth#display)

By default, foursquare auto-detects the appropriate type of site to display for the auth dialog. You can force a specific display type by adding display=XXX to your authorize or authenticate URLs. The supported display types are touch, wap, and webpopup. We don't recommend specifying a display type, **unless you are using the webpopup display.** In webpopup mode, we pop up a new web window for the auth dialog, redirect to the callback in the caller window, and close the popup window after the user authorizes the app.
